### PR TITLE
Add Alba

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers) - JSON serialization of objects.
 * [Acts_As_Api](https://github.com/fabrik42/acts_as_api) - Easy And Fun, in creating XML/JSON responses in Rails 3,4,5 and 6.
+* [Alba](https://github.com/okuramasafumi/alba) - A JSON serializer for Ruby, JRuby and TruffleRuby.
 * [Blanket](https://github.com/inf0rmer/blanket) - A dead simple API wrapper.
 * [Blueprinter](https://github.com/procore/blueprinter) - Simple, Fast, and Declarative Serialization Library for Ruby.
 * [cache_crispies](https://github.com/codenoble/cache-crispies) - Speedy Rails JSON serialization with built-in caching.


### PR DESCRIPTION
## Project

Name: Alba
URL: https://github.com/okuramasafumi/alba

## What is this Ruby project?

Alba is a JSON serializer for Ruby, JRuby and TruffleRuby.

## What are the main difference between this Ruby project and similar ones?

### Fast

It's faster than most of similar projects. There's a [benchmark](https://github.com/okuramasafumi/alba/tree/main/benchmark) in the repo to compare performance.

### Feature rich

Alba has so many good features such as layouts and conditional attributes so that it's easier to build complex JSON.

### Maintained

Unlike some other libraries, Alba is still well maintained and released regularly.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.